### PR TITLE
Add TruffleRuby & JRuby in CI and use the correct fallback pattern for rb_io_descriptor()

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ 3.0, 2.7, head ]
+        ruby: [ 3.0, 2.7, head, truffleruby, truffleruby-head ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ 3.0, 2.7, head, truffleruby, truffleruby-head ]
+        ruby: [ 3.0, 2.7, head, truffleruby, truffleruby-head, jruby, jruby-head ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Rakefile
+++ b/Rakefile
@@ -3,12 +3,17 @@ require "rake/testtask"
 
 name = "io/nonblock"
 
-require 'rake/extensiontask'
-extask = Rake::ExtensionTask.new(name) do |x|
-  x.lib_dir.sub!(%r[(?=/|\z)], "/#{RUBY_VERSION}/#{x.platform}")
+if RUBY_ENGINE == 'ruby'
+  require 'rake/extensiontask'
+  extask = Rake::ExtensionTask.new(name) do |x|
+    x.lib_dir.sub!(%r[(?=/|\z)], "/#{RUBY_VERSION}/#{x.platform}")
+  end
+else
+  task :compile
 end
+
 Rake::TestTask.new(:test) do |t|
-  t.libs = ["lib/#{RUBY_VERSION}/#{extask.platform}"]
+  t.libs = ["lib/#{RUBY_VERSION}/#{extask.platform}"] if extask
   t.libs << "test/lib"
   t.ruby_opts << "-rhelper"
   t.test_files = FileList["test/**/test_*.rb"]

--- a/ext/io/nonblock/extconf.rb
+++ b/ext/io/nonblock/extconf.rb
@@ -2,6 +2,11 @@
 require 'mkmf'
 target = "io/nonblock"
 
+unless RUBY_ENGINE == 'ruby'
+  File.write("Makefile", dummy_makefile($srcdir).join(""))
+  return
+end
+
 have_func("rb_io_descriptor")
 
 hdr = %w"fcntl.h"

--- a/ext/io/nonblock/nonblock.c
+++ b/ext/io/nonblock/nonblock.c
@@ -19,12 +19,13 @@
 
 #ifndef HAVE_RB_IO_DESCRIPTOR
 static int
-rb_io_descriptor(VALUE io)
+io_descriptor_fallback(VALUE io)
 {
     rb_io_t *fptr;
     GetOpenFile(io, fptr);
     return fptr->fd;
 }
+#define rb_io_descriptor io_descriptor_fallback
 #endif
 
 #ifdef F_GETFL


### PR DESCRIPTION
Follow-up of https://github.com/ruby/io-nonblock/pull/11, cc @ioquatix

Similar to https://github.com/ruby/etc/pull/27 and https://github.com/ruby/cgi/pull/44