### PR TITLE
mark extension as ractor safe

### DIFF
--- a/ext/io/nonblock/nonblock.c
+++ b/ext/io/nonblock/nonblock.c
@@ -197,6 +197,10 @@ rb_io_nonblock_block(int argc, VALUE *argv, VALUE self)
 void
 Init_nonblock(void)
 {
+#ifdef HAVE_RB_EXT_RACTOR_SAFE
+    rb_ext_ractor_safe(true);
+#endif
+
 #ifndef RUBY_IO_NONBLOCK_METHODS
     rb_define_method(rb_cIO, "nonblock?", rb_io_nonblock_p, 0);
     rb_define_method(rb_cIO, "nonblock=", rb_io_nonblock_set, 1);


### PR DESCRIPTION
to match what sockets already define.

Without this, it isn't possible to instantiate SSLSockets in ractors, as [these methods are called on init](https://github.com/ruby/openssl/blob/master/ext/openssl/ossl_ssl.c#L1634).