### PR TITLE
Bump up the required ruby version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
       engine: all
-      min_version: 2.7
+      min_version: 3.0
 
   test:
     needs: ruby-versions

--- a/io-nonblock.gemspec
+++ b/io-nonblock.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Enables non-blocking mode with IO class}
   spec.homepage      = "https://github.com/ruby/io-nonblock"
   spec.licenses      = ["Ruby", "BSD-2-Clause"]
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
io-nonblock became a default gem at ruby 3.0.
Even it can be installed on earlier versions, but the standard library will be loaded instead of the installed gem.